### PR TITLE
Remove restriction on json version

### DIFF
--- a/mandrill-api.gemspec
+++ b/mandrill-api.gemspec
@@ -7,6 +7,6 @@ Gem::Specification.new do |s|
     s.email = 'community@mandrill.com'
     s.files = ['lib/mandrill.rb', 'lib/mandrill/api.rb', 'lib/mandrill/errors.rb']
     s.homepage = 'https://bitbucket.org/mailchimp/mandrill-api-ruby/'
-    s.add_dependency 'json', '>= 1.7.7', '< 2.1'
+    s.add_dependency 'json', '>= 1.7.7'
     s.add_dependency 'excon', '>= 0.16.0', '< 1.0'
 end


### PR DESCRIPTION
Remove restriction on json version. The json gem has a vulnerability and Rails projects needs to use version >=2.3